### PR TITLE
DL-2144 Added rolling 5 year window function

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,16 @@ Please include a summary / description of the change and which issue it fixes.  
 
 ## Checklist
 
+*Reviewee* (Replace with your name)
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
+ - [ ]  I've run a dependency check to ensure all dependencies are up to date
+
+*Reviewer* (Replace with your name)
+ - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
+ - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
+ - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
+ - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [ ]  I've run a dependency check to ensure all dependencies are up to date

--- a/app/controllers/PropertyDetailsPeriodController.scala
+++ b/app/controllers/PropertyDetailsPeriodController.scala
@@ -46,25 +46,21 @@ trait PropertyDetailsPeriodController extends BackendController {
   def saveDraftFullTaxPeriod(atedRefNo: String, id: String) = Action.async(parse.json) {
     implicit request =>
       withJsonBody[IsFullTaxPeriod] { draftPropertyDetails =>
-        propertyDetailsService.cacheDraftFullTaxPeriod(atedRefNo, id, draftPropertyDetails).map { updatedDraftPropertyDetails =>
-          updatedDraftPropertyDetails match {
+        propertyDetailsService.cacheDraftFullTaxPeriod(atedRefNo, id, draftPropertyDetails).map {
             case Some(x) => Ok("")
             case None => BadRequest("Invalid Request")
           }
         }
-      }
   }
 
   def saveDraftInRelief(atedRefNo: String, id: String) = Action.async(parse.json) {
     implicit request =>
       withJsonBody[PropertyDetailsInRelief] { draftPropertyDetails =>
-        propertyDetailsService.cacheDraftInRelief(atedRefNo, id, draftPropertyDetails).map { updatedDraftPropertyDetails =>
-          updatedDraftPropertyDetails match {
+        propertyDetailsService.cacheDraftInRelief(atedRefNo, id, draftPropertyDetails).map {
             case Some(x) => Ok("")
             case None => BadRequest("Invalid Request")
           }
         }
-      }
   }
 
   def saveDraftDatesLiable(atedRefNo: String, id: String) = Action.async(parse.json) {

--- a/app/utils/AtedUtils.scala
+++ b/app/utils/AtedUtils.scala
@@ -24,6 +24,8 @@ import uk.gov.hmrc.http.logging.SessionId
 
 object AtedUtils {
 
+  val lowestBound = 2012
+
   def getSessionIdOrAgentCodeAsId(hc: HeaderCarrier, agentCode: String): String = {
     hc.sessionId.fold(SessionId(agentCode).value)(_.value)
   }
@@ -42,4 +44,16 @@ object AtedUtils {
     clientsAgent
   }
 
+  def enforceFiveYearBoundary(valuation: LocalDate, taxYear: Int): LocalDate = {
+    val lowerBoundary = calculateLowerTaxYearBounday(taxYear)
+    if (!(valuation isAfter lowerBoundary)) lowerBoundary else valuation
+  }
+
+  private[utils] def calculateLowerTaxYearBounday(taxYear: Int): LocalDate = {
+    val year = if (taxYear <= lowestBound) lowestBound else {
+      lowestBound + (5 * ((taxYear - lowestBound - 1) / 5).floor.toInt)
+    }
+
+    LocalDate.parse(s"$year-4-1")
+  }
 }

--- a/app/utils/LiabilityUtils.scala
+++ b/app/utils/LiabilityUtils.scala
@@ -58,7 +58,7 @@ trait LiabilityUtils extends ReliefConstants {
 
   private def createLiabilityReturns(id: String, property: PropertyDetails, propCalc: PropertyDetailsCalculated,
                                         mode: String, agentRefNo: Option[String] = None,
-                                        valuationDate : LocalDate,
+                                        valuationDate: LocalDate,
                                         professionallyValued : Boolean) = {
 
     val liabilityReturn = EtmpLiabilityReturns(mode = mode,
@@ -67,7 +67,7 @@ trait LiabilityUtils extends ReliefConstants {
       propertyDetails = Some(getEtmpPropertyDetails(property)),
       dateOfAcquisition = propCalc.acquistionDateToUse,
       valueAtAcquisition = propCalc.acquistionValueToUse,
-      dateOfValuation = valuationDate,
+      dateOfValuation = AtedUtils.enforceFiveYearBoundary(valuationDate, property.periodKey),
       taxAvoidanceScheme = getTaxAvoidanceScheme(property),
       taxAvoidancePromoterReference = getTaxAvoidancePromoterReference(property),
       professionalValuation = professionallyValued,

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -49,7 +49,7 @@
 
     <logger name="uk.gov" level="INFO"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application" level="INFO"/>
 
     <logger name="com.google.inject" level="INFO"/>
 
@@ -57,7 +57,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/test/utils/PropertyDetailsUtilsSpec.scala
+++ b/test/utils/PropertyDetailsUtilsSpec.scala
@@ -19,12 +19,11 @@ package utils
 import builders.PropertyDetailsBuilder
 import models._
 import org.joda.time.LocalDate
-import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
-import utils.PropertyDetailsUtils._
+import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.http.InternalServerException
 
 
-class PropertyDetailsUtilsSpec extends PlaySpec with ReliefConstants with OneServerPerSuite {
+class PropertyDetailsUtilsSpec extends PlaySpec with ReliefConstants {
 
   val periodStartDate = new LocalDate("2015-06-02")
   val periodEndDate = new LocalDate("2016-01-10")
@@ -749,13 +748,14 @@ class PropertyDetailsUtilsSpec extends PlaySpec with ReliefConstants with OneSer
 
     "return April 2012 if this is not revalued but was acquired before 2012 " in {
       val propVal = PropertyDetailsValue(anAcquisition = Some(false), isOwnedBeforePolicyYear = Some(true))
-      PropertyDetailsUtils.getValuationDate(Some(propVal),Some(new LocalDate("2012-04-01")), periodKey) must be (Some(new LocalDate("2012-04-01")))
+      PropertyDetailsUtils.getValuationDate(Some(propVal),Some(new LocalDate("2012-04-01")), 2015) must be (Some(new LocalDate("2012-04-01")))
+      PropertyDetailsUtils.getValuationDate(Some(propVal),Some(new LocalDate("2012-04-01")), 2019) must be (Some(new LocalDate("2017-04-01")))
     }
 
 
     "return April 2017 if this is not revalued but was acquired before 2017 " in {
       val propVal = PropertyDetailsValue(anAcquisition = Some(false), isOwnedBeforePolicyYear = Some(true))
-      PropertyDetailsUtils.getValuationDate(Some(propVal),Some(new LocalDate("2017-04-01")), 2019) must be (Some(new LocalDate("2017-04-01")))
+      PropertyDetailsUtils.getValuationDate(Some(propVal),Some(new LocalDate("2013-04-01")), 2019) must be (Some(new LocalDate("2017-04-01")))
     }
 
     "return the revalued date if this is an aquisition that has been revalued for policy year 2017" in {


### PR DESCRIPTION
# DL-2144 Added rolling 5 year window function

**Bug fix**

To prevent submissions after 2018-4-1 from submitting valuation dates before 2017-4-1. This is also a 5 year rolling change, meaning that in 2023, no valuation dates from before 2022 can be submitted.

## Checklist

*Chris*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer*  (_replace with your name_)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date