### PR TITLE
Fix for DL-2087 - intermittent issue where returns data is corrupted

### DIFF
--- a/app/utils/PropertyDetailsUtils.scala
+++ b/app/utils/PropertyDetailsUtils.scala
@@ -148,12 +148,10 @@ object PropertyDetailsUtils extends ReliefConstants {
           case (NotOwnedBeforePolicyYear, Some(true), _) => value.newBuildValue
           case (NotOwnedBeforePolicyYear, Some(false), _) => value.notNewBuildValue
           case (_, _, Some(true)) => value.revaluedValue
-          case (_, _, Some(false)) => value.revaluedValue
           case _ => None
         }
     }
   }
-
 
   def getAcquisitionValueAndDate(value: PropertyDetailsValue, periodKey: Int): (Option[BigDecimal], Option[LocalDate]) = {
     val ownedBefore = PropertyDetailsOwnedBefore(value.isOwnedBeforePolicyYear, value.ownedBeforePolicyYearValue)
@@ -164,7 +162,6 @@ object PropertyDetailsUtils extends ReliefConstants {
         value.localAuthRegDate))
       case (NotOwnedBeforePolicyYear, Some(false), _) => (value.notNewBuildValue, value.notNewBuildDate)
       case (_, _, Some(true)) => (value.revaluedValue, value.partAcqDispDate)
-      case (_, _, Some(false)) => (value.revaluedValue, value.partAcqDispDate)
       case _ => (None, None)
     }
   }

--- a/test/utils/PropertyDetailsUtilsSpec.scala
+++ b/test/utils/PropertyDetailsUtilsSpec.scala
@@ -586,15 +586,6 @@ class PropertyDetailsUtilsSpec extends PlaySpec with ReliefConstants {
       PropertyDetailsUtils.getInitialValueForSubmission(Some(propVal),periodKey) must be (Some(BigDecimal(1111.11)))
     }
 
-    "return the revalued value if this has been not benn revalued and we have no build or ownedBefore answers " in {
-      val propVal = PropertyDetailsValue(
-        isPropertyRevalued = Some(false),
-        revaluedValue = Some(BigDecimal(1111.11)))
-
-      PropertyDetailsUtils.getInitialValueForSubmission(Some(propVal),periodKey) must be (Some(BigDecimal(1111.11)))
-    }
-
-
     "return the owned before value if this has been set, even if it's been revalued" in {
       val propVal = PropertyDetailsValue(isOwnedBeforePolicyYear = Some(true),
         isNewBuild = Some(true),
@@ -712,23 +703,6 @@ class PropertyDetailsUtilsSpec extends PlaySpec with ReliefConstants {
       res._2 must be (Some(new LocalDate("2015-01-01")))
     }
 
-    "return the not new build value, even if it's not been revalued" in {
-      val propVal = PropertyDetailsValue(isOwnedBeforePolicyYear = None,
-        isNewBuild = None,
-        newBuildValue = Some(BigDecimal(3333.33)),
-        newBuildDate = Some(new LocalDate("2014-01-01")),
-        notNewBuildValue = Some(BigDecimal(4444.44)),
-        notNewBuildDate = Some(new LocalDate("2015-01-01")),
-        ownedBeforePolicyYearValue = Some(BigDecimal(2222.22)),
-        isPropertyRevalued = Some(false),
-        revaluedDate = Some(new LocalDate("2013-01-01")),
-        partAcqDispDate = Some(new LocalDate("2013-02-02")),
-        revaluedValue = Some(BigDecimal(1111.11)))
-
-      val res = PropertyDetailsUtils.getAcquisitionData(Some(propVal),periodKey)
-      res._1 must be (Some(BigDecimal(1111.11)))
-      res._2 must be (Some(new LocalDate("2013-02-02")))
-    }
   }
 
 


### PR DESCRIPTION
# JIRA Story or Github Number - descriptive title

**Bug fix**

An intermittent issue has been happening on ATED where returns are ending up in a corrupt state and cannot be saved / opened. After being unable to reliably replicate the issue, I've found a potential cause in the code which reads incorrectly and therefore could be the issue. Associated unit tests have been removed. All tests pass including ATs.

## Checklist

*David Thornton* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer*
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date