### PR TITLE
DL-2818 - deletion of 28 day logic and tests

### DIFF
--- a/app/scheduler/DeleteReliefsService.scala
+++ b/app/scheduler/DeleteReliefsService.scala
@@ -42,7 +42,7 @@ class DefaultDeleteReliefsService @Inject()(val servicesConfig: ServicesConfig,
   }
 }
 
-trait DeleteReliefsService extends ScheduledService[(Int, Int)] {
+trait DeleteReliefsService extends ScheduledService[Int] {
   lazy val repo: ReliefsMongoRepository = repository()
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -50,25 +50,18 @@ trait DeleteReliefsService extends ScheduledService[(Int, Int)] {
   val lockKeeper: LockKeeper
   val documentBatchSize: Int
 
-  private def deleteOldReliefs(datetimeToggle: Boolean = false)(implicit ec: ExecutionContext): Future[(Int, Int)] = {
-    for {
-      doc28Days <- repo.deleteExpired28Reliefs(documentBatchSize)
-      doc60Days <- repo.deleteExpired60Reliefs(documentBatchSize, datetimeToggle)
-    } yield {
-      Logger.info(s"[DeleteLiabilityReturnsService][deleteOldLiabilityReturns] Deleted $doc28Days draft documents past the 28 day limit")
-      Logger.info(s"[DeleteLiabilityReturnsService][deleteOldLiabilityReturns] Deleted $doc60Days draft documents past the 60 day limit")
-      (doc28Days, doc60Days)
-    }
+  private def deleteOldReliefs()(implicit ec: ExecutionContext): Future[Int] = {
+     repo.deleteExpired60Reliefs(documentBatchSize)
   }
 
-	def invoke(datetimeToggle: Boolean = false)(implicit ec: ExecutionContext): Future[(Int, Int)] = {
-    lockKeeper.tryLock(deleteOldReliefs(datetimeToggle)) map {
+	def invoke()(implicit ec: ExecutionContext): Future[Int] = {
+    lockKeeper.tryLock(deleteOldReliefs()) map {
       case Some(result) =>
 				Logger.info(s"[DeleteReliefsService] Deleted $result draft documents past the 28 day limit")
         result
       case None         =>
 				Logger.warn(s"[DeleteReliefsService] Failed to acquire lock")
-        (0, 0)
+       0
     }
   }
 }

--- a/app/scheduler/ScheduledService.scala
+++ b/app/scheduler/ScheduledService.scala
@@ -19,5 +19,5 @@ package scheduler
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ScheduledService[R] {
-  def invoke(datetimeToggle: Boolean = false)(implicit ec : ExecutionContext) : Future[R]
+  def invoke()(implicit ec : ExecutionContext) : Future[R]
 }

--- a/app/scheduler/SchedulingActor.scala
+++ b/app/scheduler/SchedulingActor.scala
@@ -32,12 +32,12 @@ class SchedulingActor extends Actor with ActorLogging {
 
 object SchedulingActor {
   sealed trait ScheduledMessage[A] {
-    val service: ScheduledService[(Int, Int)]
+    val service: ScheduledService[Int]
   }
 
-  case class deletePropertyDetailsDrafts(service: DeletePropertyDetailsService) extends ScheduledMessage[(Int, Int)]
-	case class deleteReliefDrafts(service: DeleteReliefsService) extends ScheduledMessage[(Int, Int)]
-	case class deleteLiabilityReturns(service: DeleteLiabilityReturnsService) extends ScheduledMessage[(Int, Int )]
+  case class deletePropertyDetailsDrafts(service: DeletePropertyDetailsService) extends ScheduledMessage[Int]
+	case class deleteReliefDrafts(service: DeleteReliefsService) extends ScheduledMessage[Int]
+	case class deleteLiabilityReturns(service: DeleteLiabilityReturnsService) extends ScheduledMessage[Int]
 
 
 	def props: Props = Props[SchedulingActor]

--- a/it/service/DeleteReliefsServiceISpec.scala
+++ b/it/service/DeleteReliefsServiceISpec.scala
@@ -16,17 +16,11 @@ import scala.concurrent.Future
 
 class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers with FutureAwaits {
   val deleteReliefsService: DeleteReliefsService = app.injector.instanceOf[DeleteReliefsService]
-  val date27DaysAgo: DateTime = DateTime.parse("2020-02-27").withHourOfDay(0).minusDays(27)
-  val date28DaysAgo: DateTime = date27DaysAgo.minusDays(1)
-  val date28DaysHrsMinsAgo: DateTime = date27DaysAgo.minusDays(1).minusHours(23).minusMinutes(59)
-  val date29DaysAgo: DateTime = date27DaysAgo.minusDays(2)
-  val date29DaysMinsAgo: DateTime = date27DaysAgo.minusDays(2).minusMinutes(1)
-  val date59DaysAgo: DateTime = DateTime.parse("2020-10-10").withHourOfDay(0).minusDays(59)
+  val date59DaysAgo: DateTime = DateTime.now.withHourOfDay(0).minusDays(59)
   val date60DaysAgo: DateTime = date59DaysAgo.minusDays(1)
   val date60DaysHrsMinsAgo: DateTime = date59DaysAgo.minusDays(1).minusHours(23).minusMinutes(59)
   val date61DaysAgo: DateTime = date59DaysAgo.minusDays(2)
   val date61DaysMinsAgo: DateTime = date59DaysAgo.minusDays(2).minusMinutes(1)
-
 
   val periodKey = 2019
 
@@ -74,124 +68,15 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
       .post(Json.toJson(reliefTaxAvoidance("SoDoesThis")))
 
     "not delete any drafts" when {
-      "the draft has only just been added" in new Setup {
-        stubAuthPost
-
-        await(createRelief)
-        val deleteCount = await(deleteReliefsService.invoke())
-        val retrieve = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-
-        deleteCount mustBe (0,0)
-        retrieve.status mustBe OK
-      }
-
-      "the draft has been stored for 27 days" in new Setup {
-        stubAuthPost
-
-        await(createRelief)
-        await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date27DaysAgo))
-        val deleteCount = await(deleteReliefsService.invoke())
-        val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-
-        deleteCount mustBe (0,0)
-        foundDraft.status mustBe OK
-      }
-
-      "the draft has been stored for 28 days 23 hrs and 59 mins" in new Setup {
-        stubAuthPost
-
-        await(createRelief)
-        await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date28DaysHrsMinsAgo))
-        val deleteCount = await(deleteReliefsService.invoke())
-        val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-
-        deleteCount mustBe (0,0)
-        foundDraft.status mustBe OK
-      }
-    }
-
-    "delete the relief drafts" when {
-      "the draft has been stored for 29 days" in new Setup {
-        stubAuthPost
-
-        await(createRelief)
-        await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date29DaysAgo))
-
-        await(repo.collection.count()) mustBe 1
-
-        val deleteCount = await(deleteReliefsService.invoke())
-        val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-
-        deleteCount mustBe (1,0)
-        deletedDraft.status mustBe NOT_FOUND
-      }
-
-      "the draft has been stored for 29 days and 1 min" in new Setup {
-        stubAuthPost
-
-        await(createRelief)
-        await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date29DaysMinsAgo))
-
-        await(repo.collection.count()) mustBe 1
-
-        val deleteCount = await(deleteReliefsService.invoke())
-        val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-
-        deleteCount mustBe (1,0)
-        deletedDraft.status mustBe NOT_FOUND
-      }
-    }
-
-    "only delete outdated reliefs when multiple reliefs exist" in new Setup {
-      stubAuthPost
-
-      await(createRelief)
-      await(createRelief2)
-      await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date29DaysAgo))
-
-      await(repo.collection.count()) mustBe 2
-
-      val deleteCount = await(deleteReliefsService.invoke())
-      val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-      val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE7654321XX/ated/reliefs/$periodKey").get())
-
-      deleteCount mustBe (1,0)
-      deletedDraft.status mustBe NOT_FOUND
-      foundDraft.status mustBe OK
-    }
-
-    "delete multiple drafts when the batchSize is >1" in new Setup {
-      stubAuthPost
-
-      await(createRelief)
-      await(createRelief2)
-      await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date29DaysAgo))
-      await(repo.updateTimeStamp(reliefTaxAvoidance("ATE7654321XX"), date29DaysAgo))
-
-      await(repo.collection.count()) mustBe 2
-
-      val deleteCount = await(deleteReliefsService.invoke())
-
-      await(repo.collection.count()) mustBe 0
-
-      val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
-      val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE7654321XX/ated/reliefs/$periodKey").get())
-      
-      deleteCount mustBe (2,0)
-      deletedDraft.status mustBe NOT_FOUND
-      foundDraft.status mustBe NOT_FOUND
-    }
-
-    "not delete any drafts" when {
       "the draft has only just been added for 60days" in new Setup {
         stubAuthPost
 
         await(createRelief)
         await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), DateTime.parse("2020-10-10")))
-        val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+        val deleteCount = await(deleteReliefsService.invoke())
         val retrieve = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
 
-        deleteCount mustBe (0,0)
+        deleteCount mustBe 0
         retrieve.status mustBe OK
       }
 
@@ -200,10 +85,10 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
         await(createRelief)
         await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date59DaysAgo))
-        val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+        val deleteCount = await(deleteReliefsService.invoke())
         val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
 
-        deleteCount mustBe (0,0)
+        deleteCount mustBe 0
         foundDraft.status mustBe OK
       }
 
@@ -212,10 +97,10 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
         await(createRelief)
         await(repo.updateTimeStamp(reliefTaxAvoidance("ATE1234567XX"), date60DaysHrsMinsAgo))
-        val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+        val deleteCount = await(deleteReliefsService.invoke())
         val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
 
-        deleteCount mustBe (0,0)
+        deleteCount mustBe 0
         foundDraft.status mustBe OK
       }
     }
@@ -229,10 +114,10 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
         await(repo.collection.count()) mustBe 1
 
-        val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+        val deleteCount = await(deleteReliefsService.invoke())
         val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
 
-        deleteCount mustBe (0,1)
+        deleteCount mustBe 1
         deletedDraft.status mustBe NOT_FOUND
       }
 
@@ -244,10 +129,10 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
         await(repo.collection.count()) mustBe 1
 
-        val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+        val deleteCount = await(deleteReliefsService.invoke())
         val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
 
-        deleteCount mustBe (0,1)
+        deleteCount mustBe 1
         deletedDraft.status mustBe NOT_FOUND
       }
     }
@@ -263,11 +148,11 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
       await(repo.collection.count()) mustBe 2
 
-      val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+      val deleteCount = await(deleteReliefsService.invoke())
       val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
       val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE7654321XX/ated/reliefs/$periodKey").get())
 
-      deleteCount mustBe (0,1)
+      deleteCount mustBe 1
       deletedDraft.status mustBe NOT_FOUND
       foundDraft.status mustBe OK
     }
@@ -282,14 +167,14 @@ class DeleteReliefsServiceISpec extends IntegrationSpec with AssertionHelpers wi
 
       await(repo.collection.count()) mustBe 2
 
-      val deleteCount = await(deleteReliefsService.invoke(datetimeToggle = true))
+      val deleteCount = await(deleteReliefsService.invoke())
 
       await(repo.collection.count()) mustBe 0
 
       val deletedDraft = await(hitApplicationEndpoint(s"/ated/ATE1234567XX/ated/reliefs/$periodKey").get())
       val foundDraft = await(hitApplicationEndpoint(s"/ated/ATE7654321XX/ated/reliefs/$periodKey").get())
 
-      deleteCount mustBe (0,2)
+      deleteCount mustBe 2
       deletedDraft.status mustBe NOT_FOUND
       foundDraft.status mustBe NOT_FOUND
     }


### PR DESCRIPTION
DL-2818 - deletion of 28 day logic and tests

Removal of 28 day storage logic as it is now redundant. 

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date