### PR TITLE
DL-6549 play28 upgrade plus dependencies and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val scoverageSettings: Seq[Def.Setting[_ >: String with Double with Boolean
   import scoverage.ScoverageKeys
   Seq(
     ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;app.Routes.*;prod.*;uk.gov.hmrc.*;testOnlyDoNotUseInAppConf.*;forms.*;models.*;config.*;",
-    ScoverageKeys.coverageMinimum := 95,
+    ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     parallelExecution in Test := false
@@ -49,7 +49,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full,
-      "uk.gov.hmrc" %% "auth-client" % "3.2.0-play-27"
+      "uk.gov.hmrc" %% "auth-client" % "5.7.0-play-28"
     )
   )
   .settings(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,9 +25,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,12 +8,12 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
 		"com.enragedginger" %% "akka-quartz-scheduler"      % "1.9.1-akka-2.6.x",
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"  % "5.2.0",
-    "uk.gov.hmrc"       %% "domain"                     % "5.11.0-play-27",
-    "uk.gov.hmrc"       %% "simple-reactivemongo"       % "8.0.0-play-27",
-    "uk.gov.hmrc"       %% "json-encryption"            % "4.10.0-play-27",
-		"uk.gov.hmrc"			  %% "mongo-lock"					        % "7.0.0-play-27",
-		"com.typesafe.play" %% "play-json-joda"             % "2.7.4"
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28"  % "5.16.0",
+    "uk.gov.hmrc"       %% "domain"                     % "6.2.0-play-28",
+    "uk.gov.hmrc"       %% "simple-reactivemongo"       % "8.0.0-play-28",
+    "uk.gov.hmrc"       %% "json-encryption"            % "4.10.0-play-28",
+		"uk.gov.hmrc"			  %% "mongo-lock"					        % "7.0.0-play-28",
+		"com.typesafe.play" %% "play-json-joda"             % "2.9.2"
   )
 
   trait TestDependencies {
@@ -24,11 +24,12 @@ object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test: Seq[ModuleID] = Seq(
-        "org.scalatestplus.play"  %% "scalatestplus-play" % "4.0.3"             % scope,
-        "org.pegdown"              % "pegdown"            % "1.6.0"             % scope,
-        "org.mockito"              % "mockito-core"       % "3.10.0"            % scope,
-        "com.typesafe.play"       %% "play-test"          % PlayVersion.current % scope,
-        "uk.gov.hmrc"             %% "reactivemongo-test" % "4.22.0-play-27"    % scope
+        "org.scalatestplus.play"       %% "scalatestplus-play"   % "5.1.0"             % scope,
+        "org.pegdown"                  %  "pegdown"              % "1.6.0"             % scope,
+        "org.mockito"                  %  "mockito-core"         % "3.12.4"            % scope,
+        "com.typesafe.play"            %% "play-test"            % PlayVersion.current % scope,
+        "uk.gov.hmrc"                  %% "reactivemongo-test"   % "5.0.0-play-28"     % scope,
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.5"            % scope
       )
     }.test
   }
@@ -36,10 +37,12 @@ object AppDependencies {
 	object IntegrationTest {
 		def apply(): Seq[ModuleID] = new TestDependencies {
 			override lazy val test = Seq(
-				"org.pegdown" 					 % "pegdown" 							 % 	"1.6.0"								  % scope,
-				"com.typesafe.play"			 %% "play-test" 				 	 % 	PlayVersion.current 		% scope,
-				"org.scalatestplus.play" %% "scalatestplus-play"	 % 	"4.0.3" 								% scope,
-				"com.github.tomakehurst" % "wiremock-jre8"				 %  "2.28.0"                % scope
+				"org.pegdown" 					 %  "pegdown" 					 % 	"1.6.0"						  % scope,
+				"com.typesafe.play"			 %% "play-test" 				 % 	PlayVersion.current % scope,
+				"org.scalatestplus.play" %% "scalatestplus-play" % 	"5.1.0" 						% scope,
+        "org.scalatestplus"      %% "mockito-3-12"       % "3.2.10.0"           % scope,
+        "com.vladsch.flexmark"   %  "flexmark-all"       %  "0.35.10"           % scope,
+				"com.github.tomakehurst" %  "wiremock-jre8"			 %  "2.31.0"            % scope
 			)
 		}.test
 	}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.1")

--- a/test/utils/JsonOptionDecryptorSpec.scala
+++ b/test/utils/JsonOptionDecryptorSpec.scala
@@ -32,12 +32,12 @@ package utils
  * limitations under the License.
  */
 
-import org.scalatest.{Matchers, WordSpec}
-import play.api.libs.json.{JsString, Json}
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsString, Json, OFormat}
 import uk.gov.hmrc.crypto.json._
 import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Protected, _}
 
-class JsonEncryptionSpec extends WordSpec with Matchers {
+class JsonEncryptionSpec extends PlaySpec {
 
   "formatting an entity" should {
 
@@ -51,10 +51,10 @@ class JsonEncryptionSpec extends WordSpec with Matchers {
 
       val json = Json.toJson(e)(TestEntity.formats)
 
-      (json \ "normalString").get shouldBe JsString("unencrypted")
-      (json \ "encryptedString").get shouldBe JsString("3TW3L1raxsKBYuKvtKqPEQ==")
-      (json \ "encryptedBoolean").get shouldBe JsString("YhWm43Ad3rW5Votdy855Kg==")
-      (json \ "encryptedNumber").get shouldBe JsString("Z/ipDOvm7C3ck/TBkiteAg==")
+      (json \ "normalString").get mustBe JsString("unencrypted")
+      (json \ "encryptedString").get mustBe JsString("3TW3L1raxsKBYuKvtKqPEQ==")
+      (json \ "encryptedBoolean").get mustBe JsString("YhWm43Ad3rW5Votdy855Kg==")
+      (json \ "encryptedNumber").get mustBe JsString("Z/ipDOvm7C3ck/TBkiteAg==")
 
     }
 
@@ -68,10 +68,10 @@ class JsonEncryptionSpec extends WordSpec with Matchers {
 
       val json = Json.toJson(e)(TestEntity.formats)
 
-      (json \ "normalString").get shouldBe JsString("unencrypted")
-      (json \ "encryptedString").get shouldBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
-      (json \ "encryptedBoolean").get shouldBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
-      (json \ "encryptedNumber").get shouldBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
+      (json \ "normalString").get mustBe JsString("unencrypted")
+      (json \ "encryptedString").get mustBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
+      (json \ "encryptedBoolean").get mustBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
+      (json \ "encryptedNumber").get mustBe JsString("rEMu/lGbPQCXd8ohhLl47A==")
 
     }
 
@@ -86,7 +86,7 @@ class JsonEncryptionSpec extends WordSpec with Matchers {
 
       val entity = Json.fromJson(Json.parse(jsonString))(TestEntity.formats).get
 
-      entity shouldBe TestEntity("unencrypted",
+      entity mustBe TestEntity("unencrypted",
         Protected[Option[String]](Some("encrypted")),
         Protected[Option[Boolean]](Some(true)),
         Protected[Option[BigDecimal]](Some(BigDecimal("234")))
@@ -105,7 +105,7 @@ class JsonEncryptionSpec extends WordSpec with Matchers {
 
       val entity = Json.fromJson(Json.parse(jsonString))(TestEntity.formats).get
 
-      entity shouldBe TestEntity("unencrypted",
+      entity mustBe TestEntity("unencrypted",
         Protected[Option[String]](None),
         Protected[Option[Boolean]](None),
         Protected[Option[BigDecimal]](None)
@@ -130,7 +130,7 @@ case class TestEntity(normalString: String,
 
 object TestEntity {
 
-  implicit val crypto = Crypto
+  implicit val crypto: Crypto.type = Crypto
 
   object JsonStringEncryption extends JsonEncryptor[Option[String]]
   object JsonBooleanEncryption extends JsonEncryptor[Option[Boolean]]
@@ -140,14 +140,14 @@ object TestEntity {
   object JsonBooleanDecryption extends JsonOptionDecryptor[Boolean]
   object JsonBigDecimalDecryption extends JsonOptionDecryptor[BigDecimal]
 
-  implicit val formats = {
-    implicit val encryptedStringFormats= JsonStringEncryption
-    implicit val encryptedBooleanFormats = JsonBooleanEncryption
-    implicit val encryptedBigDecimalFormats = JsonBigDecimalEncryption
+  implicit val formats: OFormat[TestEntity] = {
+    implicit val encryptedStringFormats: JsonStringEncryption.type = JsonStringEncryption
+    implicit val encryptedBooleanFormats: JsonBooleanEncryption.type = JsonBooleanEncryption
+    implicit val encryptedBigDecimalFormats: JsonBigDecimalEncryption.type = JsonBigDecimalEncryption
 
-    implicit val decryptedStringFormats = JsonStringDecryption
-    implicit val decryptedBooleanFormats = JsonBooleanDecryption
-    implicit val decryptedBigDecimalFormats = JsonBigDecimalDecryption
+    implicit val decryptedStringFormats: JsonStringDecryption.type = JsonStringDecryption
+    implicit val decryptedBooleanFormats: JsonBooleanDecryption.type = JsonBooleanDecryption
+    implicit val decryptedBigDecimalFormats: JsonBigDecimalDecryption.type = JsonBigDecimalDecryption
 
     Json.format[TestEntity]
   }
@@ -156,5 +156,5 @@ object TestEntity {
 case class TestForm(name: String, sname: String, amount: Int, isValid: Boolean)
 
 object TestForm {
-  implicit val formats = Json.format[TestForm]
+  implicit val formats: OFormat[TestForm] = Json.format[TestForm]
 }


### PR DESCRIPTION
# DL-6549

**Maintenance**

Upgrade to play28
Update dependencies and plugins

Note - Specifically added dependency for jackson-module-scala however it is possible to not use this and downgrade wiremock-jre8 to version that has a compatible version

Used mockito-core 3.12.4 (rather than upgrade to 4.0.0) as this according to the documentation is the version to be used with test dependency: mockito-3-12 (https://github.com/scalatest/scalatestplus-mockito)

## Checklist

*Reviewee* (Paul Anderson)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date